### PR TITLE
Fixes handling of exception info

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ mapped to in the log output:
 | DEBUG | 500           |
 | TRACE | 600           |
 
+## Advanced usage: Exceptions
+
+Normally, all keyword arguments are faithfully passed into the `CosmologEvent`
+payload field, except in the case of logging exceptions. Here, the conventions
+of the builtin logging library are followed. Calling `Cosmologger.exception` or
+any of the other logging methods with the keyword argument `exc_info=1` will
+add traceback information to the payload's `exc_text` field. If there is no
+`{exc_text}` specified in the format string, then the format field will be
+appended with `'\n{exc_text}'`.
+
 ## Development
 
     pip install -e .[test]

--- a/cosmolog/cosmologger.py
+++ b/cosmolog/cosmologger.py
@@ -272,7 +272,7 @@ class CosmologgerFormatter(logging.Formatter):
     def _prepare_format(self, record):
         if record.msg is None:
             return None
-        if record.exc_info and 'exc_text' not in record.msg:
+        if record.exc_info and '{exc_text}' not in record.msg:
             return record.getMessage() + '\n{exc_text}'
         return record.getMessage()
 

--- a/cosmolog/cosmologger.py
+++ b/cosmolog/cosmologger.py
@@ -258,11 +258,11 @@ class CosmologgerFormatter(logging.Formatter):
         self._version = kwargs.pop('version')
         logging.Formatter.__init__(self, *args, **kwargs)
 
-    def _prepare_exception(self, record):
-        return record.exc_text
-
     def _prepare_payload(self, record):
-        return record.__dict__.get('payload', {})
+        pld = record.__dict__.get('payload', {})
+        if record.exc_info:
+            pld['exc_text'] = record.exc_text
+        return pld
 
     def _prepare_timestamp(self, record):
         if hasattr(record, 'created'):
@@ -270,10 +270,10 @@ class CosmologgerFormatter(logging.Formatter):
         return datetime.now(utc)
 
     def _prepare_format(self, record):
-        if record.exc_info:
-            return self._prepare_exception(record)
         if record.msg is None:
             return None
+        if record.exc_info and 'exc_text' not in record.msg:
+            return record.getMessage() + '\n{exc_text}'
         return record.getMessage()
 
     def _prepare_log_event(self, record):


### PR DESCRIPTION
The new way stores the `exc_text` in the payload of a unilog message,
and ensures that the `exc_text` key appears in the format string, so
that no formatting happens to the exception text itself.