### PR TITLE
Provide more detailed CosmologEvent validation error messages

### DIFF
--- a/cosmolog/cosmologger.py
+++ b/cosmolog/cosmologger.py
@@ -148,7 +148,9 @@ class CosmologEvent(dict):
     @classmethod
     def _validate_origin(cls, origin):
         if len(origin) > 255:
-            msg = 'Origin length cannot exceed 255 characters'
+            msg = ('Invalid origin: "{}". '
+                   'Origin length cannot exceed 255 characters'
+                   ).format(origin)
             raise CosmologgerException('ValidationError', msg)
         pattern = re.compile("(?!-)[A-Z0-9-]{1,63}(?<!-)$", re.IGNORECASE)
         for part in origin.split('.'):
@@ -160,14 +162,17 @@ class CosmologEvent(dict):
     def _validate_stream_name(cls, stream_name):
         matches = re.match(r'[a-z0-9][a-z0-9._-]+', stream_name)
         if matches is None or matches.group(0) != stream_name:
-            msg = ('Stream name can contain lowercase alphanumeric characters,'
-                   ' and "_", "-", "."')
+            msg = ('Invalid stream_name: "{}". '
+                   'Stream name can contain lowercase alphanumeric '
+                   'characters, and "_", "-", "."').format(stream_name)
             raise CosmologgerException('ValidationError', msg)
 
     @classmethod
     def _validate_payload(cls, payload):
         if not isinstance(payload, collections.Mapping):
-            msg = 'Payload must be a dictionary, not {}'.format(payload)
+            msg = ('Invalid payload: "{}". '
+                   'Payload must be a dictionary, not type {}'
+                   ).format(payload, type(payload))
             raise CosmologgerException(msg)
         return {k: v for k, v in payload.iteritems()
                 if cls._validate_payload_key(k) and
@@ -177,8 +182,9 @@ class CosmologEvent(dict):
     def _validate_payload_key(cls, key):
         m = re.match(r'[a-zA-Z0-9][a-zA-Z0-9_]+', key)
         if m is None or m.group(0) != key:
-            msg = ('Payload keys can contain alphanumeric characters and '
-                   'underscores.')
+            msg = ('Invalid payload key: "{}". '
+                   'Payload keys can contain alphanumeric characters and '
+                   'underscores.').format(key)
             raise CosmologgerException('ValidationError', msg)
         return True
 
@@ -187,8 +193,10 @@ class CosmologEvent(dict):
     @classmethod
     def _validate_payload_value(cls, value):
         if type(value) not in cls._primitive_types:
-            msg = ('Payload values can be any scalar type. No lists, dicts or '
-                   'other complex types. Not {}'.format(type(value)))
+            msg = ('Invalid payload value: "{}". '
+                   'Payload values can be any scalar type. No lists, dicts or '
+                   'other complex types. Not type {}'
+                   ).format(value, type(value))
             raise CosmologgerException('ValidationError', msg)
         return True
 


### PR DESCRIPTION
I encountered an issue today where having a more detailed error message would have been quite helpful for debugging purposes.

**Example stacktrace:**
```
api_host_1        | Traceback (most recent call last):
api_host_1        |   File "/usr/lib/python2.7/logging/__init__.py", line 851, in emit
api_host_1        |     msg = self.format(record)
api_host_1        |   File "/usr/lib/python2.7/logging/__init__.py", line 724, in format
api_host_1        |     return fmt.format(record)
api_host_1        |   File "/usr/local/lib/python2.7/dist-packages/cosmolog/cosmologger.py", line 295, in format
api_host_1        |     e = self._prepare_log_event(record)
api_host_1        |   File "/usr/local/lib/python2.7/dist-packages/cosmolog/cosmologger.py", line 287, in _prepare_log_event
api_host_1        |     'payload': self._prepare_payload(record)
api_host_1        |   File "/usr/local/lib/python2.7/dist-packages/cosmolog/cosmologger.py", line 109, in from_dict
api_host_1        |     return cls(**d)
api_host_1        |   File "/usr/local/lib/python2.7/dist-packages/cosmolog/cosmologger.py", line 96, in __init__
api_host_1        |     self._validate_stream_name(stream_name)
api_host_1        |   File "/usr/local/lib/python2.7/dist-packages/cosmolog/cosmologger.py", line 165, in _validate_stream_name
api_host_1        |     raise CosmologgerException('ValidationError', msg)
api_host_1        | CosmologgerException: ('ValidationError', 'Stream name can contain lowercase alphanumeric characters, and "_", "-", "."')
```

In this example, the bad stream_name is not exposed.

**Proposed solution:** 
include the invalid entity (stream_name, origin, payload, etc.) in the `CosmologEvent` validation error messages.