### PR TITLE
allow dots and dashes in payload keys

### DIFF
--- a/cosmolog/cosmologger.py
+++ b/cosmolog/cosmologger.py
@@ -153,7 +153,7 @@ class CosmologEvent(dict):
                    'Origin length cannot exceed 255 characters'
                    ).format(origin)
             raise CosmologgerException('ValidationError', msg)
-        pattern = re.compile("(?!-)[A-Z0-9-]{1,63}(?<!-)$", re.IGNORECASE)
+        pattern = re.compile("(?!-)[A-Z0-9_-]{1,63}(?<!-)$", re.IGNORECASE)
         for part in origin.split('.'):
             if not pattern.match(part):
                 msg = 'Origin must be a fully qualified domain name'

--- a/tests/test_cosmolog_event.py
+++ b/tests/test_cosmolog_event.py
@@ -125,3 +125,20 @@ def test_null_values_in_payload(basic_event):
     kwargs['payload']['sensor'] = None
     e = CosmologEvent(**kwargs)
     assert e == kwargs
+
+
+def test_payload_keys_with_dots(basic_event):
+    basic_event['payload'] = {
+        'sun.distance': 146e6,
+        'moon.distance': 384400
+    }
+    e = CosmologEvent(**basic_event)
+    assert e == basic_event
+
+
+def test_payload_keys_with_dashes(basic_event):
+    basic_event['payload'] = {
+        'sun-distance': 146e6,
+    }
+    e = CosmologEvent(**basic_event)
+    assert e == basic_event

--- a/tests/test_cosmolog_event.py
+++ b/tests/test_cosmolog_event.py
@@ -142,3 +142,9 @@ def test_payload_keys_with_dashes(basic_event):
     }
     e = CosmologEvent(**basic_event)
     assert e == basic_event
+
+
+def test_origin_with_underscores(basic_event):
+    basic_event['origin'] = 'black_hole'
+    e = CosmologEvent(**basic_event)
+    assert e == basic_event

--- a/tests/test_cosmologger.py
+++ b/tests/test_cosmologger.py
@@ -280,3 +280,23 @@ def test_exception_human(cosmolog, cosmolog_setup):
 
     out = logstream.getvalue()
     assert out == 'Apr 13 03:07:53 jupiter.planets.com apollo13: [ERROR] Something bad happened\n{}'.format(tb)  # noqa: E501
+
+
+def test_payload_with_dots(cosmolog, cosmolog_setup):
+    logpath = cosmolog_setup()
+    logger = cosmolog()
+    logger.info(**{'jupiter.ganymede_g': 1.428, 'jupiter.europa_g': 1.315})
+    out = _log_output(logpath)
+    assert out['format'] is None
+    assert out['payload']['jupiter.ganymede_g'] == 1.428
+    assert out['payload']['jupiter.europa_g'] == 1.315
+
+
+def test_payload_with_dashes(cosmolog, cosmolog_setup):
+    logpath = cosmolog_setup()
+    logger = cosmolog()
+    logger.info(**{'jupiter-ganymede_g': 1.428, 'jupiter-europa_g': 1.315})
+    out = _log_output(logpath)
+    assert out['format'] is None
+    assert out['payload']['jupiter-ganymede_g'] == 1.428
+    assert out['payload']['jupiter-europa_g'] == 1.315

--- a/tests/test_human.py
+++ b/tests/test_human.py
@@ -49,3 +49,27 @@ def test_bad_json(cli_tester):
     r = cli_tester([], l)
     assert r.exit_code == 0
     assert r.output == expected
+
+
+def test_payload_keys_with_dots(cli_tester):
+    l = ('{"version": 0, "stream_name": "distances", '
+         '"origin": "earth", '
+         '"timestamp": "2016-09-02T16:34:12.019105Z", '
+         '"format": "distance to sun is {sun.distance}", "level": 400,'
+         '"payload": {"sun.distance": 9}}')
+    expected = 'Sep 02 16:34:12 earth distances: [INFO] distance to sun is 9\n'
+    r = cli_tester([], l)
+    assert r.exit_code == 0
+    assert r.output == expected
+
+
+def test_payload_keys_with_dashes(cli_tester):
+    l = ('{"version": 0, "stream_name": "distances", '
+         '"origin": "earth", '
+         '"timestamp": "2016-09-02T16:34:12.019105Z", '
+         '"format": "distance to sun is {sun-distance}", "level": 400,'
+         '"payload": {"sun-distance": 9}}')
+    expected = 'Sep 02 16:34:12 earth distances: [INFO] distance to sun is 9\n'
+    r = cli_tester([], l)
+    assert r.exit_code == 0
+    assert r.output == expected


### PR DESCRIPTION
The original rationale for not allowing dots was so that python
things like kwargs and str.format() would just work. But lots of
data out there has names with dots. And supporting it is not that
hard. So let's allow this.