### PR TITLE
wip: python3 support

### DIFF
--- a/cosmolog/bin/cli.py
+++ b/cosmolog/bin/cli.py
@@ -27,7 +27,7 @@ def cli():
 
 
 def _format_exception(line, e, no_color):
-    msg = 'Failed to interpret \'{}\': {}'.format(line, e.message)
+    msg = 'Failed to interpret \'{}\': {}'.format(line, e.args[0])
     if not no_color:
         msg = '\033[31m{}\033[0m'.format(msg)
     return msg

--- a/tests/test_cosmologger.py
+++ b/tests/test_cosmologger.py
@@ -20,10 +20,7 @@ import logging.config
 import pytest
 import traceback
 
-try:
-    import cStringIO as StringIO
-except ImportError:
-    import StringIO
+from six import StringIO
 
 from freezegun import freeze_time
 
@@ -38,7 +35,7 @@ from cosmolog import (setup_logging,
 def cosmolog_setup():
     '''Sets up cosmolog and returns the log file as a StringIO object'''
     def prepare_cosmolog_setup(level='INFO', origin=None, formatter='cosmolog'):  # noqa: E501
-        log_stream = StringIO.StringIO()
+        log_stream = StringIO()
         origin = origin or 'jupiter.planets.com'
         custom_config = {
             'version': 1,

--- a/tests/test_human.py
+++ b/tests/test_human.py
@@ -17,7 +17,7 @@
 import pytest
 
 from click.testing import CliRunner
-from StringIO import StringIO
+from six import StringIO
 
 from cosmolog.bin.cli import human
 


### PR DESCRIPTION
Hi friends. I've been enjoying using cosmolog in python 3.

Here are some changes I needed in order to support python 3.
I've been testing them in a `cosmolog-dtkav` package.

This might work nicely with #2 (adds tox support).

Regarding the changes:
- exception.message was deprecated in python 2.6 (args[0] uses the first argument to the exception, usually the 'message')
- python3 doesn't have `long`, so `six.integer_types` is `(int,)` in python3 and `(int, long)` in python2
- basestring is replaced by `six.string_types`
- `six.iteritems(...)` replaces `iteritems()`