### PR TITLE
Added support for newstr as a scalar for better Python 2/3 Support

### DIFF
--- a/cosmolog/cosmologger.py
+++ b/cosmolog/cosmologger.py
@@ -26,6 +26,7 @@ from datetime import datetime
 from dateutil.parser import parse as dateparse
 from pytz import utc
 from past.builtins import long, unicode, basestring
+from builtins import str as newstr
 
 
 FATAL = 100
@@ -190,7 +191,8 @@ class CosmologEvent(dict):
             raise CosmologgerException('ValidationError', msg)
         return True
 
-    _primitive_types = (bool, int, float, long, str, unicode, type(None))
+    _primitive_types = (bool, int, float, long, str, unicode, type(None),
+                        newstr)
 
     @classmethod
     def _validate_payload_value(cls, value):

--- a/tests/test_cosmologger.py
+++ b/tests/test_cosmologger.py
@@ -27,6 +27,7 @@ except ImportError:
     from io import StringIO
 
 from freezegun import freeze_time
+from builtins import str as newstr
 
 from cosmolog import (setup_logging,
                       Cosmologger,
@@ -163,6 +164,16 @@ def test_human_format_and_payload(cosmolog, cosmolog_setup):
     assert logline == 'Apr 13 03:07:53 jupiter.planets.com star_stuff: [ERROR] the oxygen tank has exploded'  # noqa: E501
 
 
+@freeze_time("1970-04-13T03:07:53Z")
+def test_human_format_and_payload_with_newstr(cosmolog, cosmolog_setup):
+    logstream = cosmolog_setup(formatter='human')
+    logger = cosmolog()
+    msg = 'the {component} has exploded'
+    logger.error(msg, component=newstr('oxygen tank'))
+    logline = logstream.getvalue().split('\n').pop(0)
+    assert logline == 'Apr 13 03:07:53 jupiter.planets.com star_stuff: [ERROR] the oxygen tank has exploded'  # noqa: E501
+
+
 def test_payload_is_validated(cosmolog, cosmolog_setup, capsys):
     cosmolog_setup()
     logger = cosmolog()
@@ -171,6 +182,15 @@ def test_payload_is_validated(cosmolog, cosmolog_setup, capsys):
     out, err = capsys.readouterr()
     assert 'CosmologgerException' in err
     assert 'ValidationError' in err
+
+
+def test_newstr_is_accepted(cosmolog, cosmolog_setup, capsys):
+    cosmolog_setup()
+    logger = cosmolog()
+    logger.info('someone is from the future: {futstr}',
+                futstr=newstr("hi from the future"))
+    out, err = capsys.readouterr()
+    assert not err
 
 
 @freeze_time("1970-04-13T03:07:53Z")

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,13 @@
 envlist = lint,py27,py36
 
 [testenv]
+platform = linux: linux
+           mac: darwin
 setenv =
-    LC_ALL=C.UTF-8
-    LANG=C.UTF-8
+    mac: LC_ALL=en_US.UTF-8
+    mac: LANG=en_US.UTF-8
+    linux: LC_ALL=C.UTF-8
+    linux: LANG=C.UTF-8
 deps =
     .[test]
     future>=0.17


### PR DESCRIPTION
This allows newstr's (backported python 3 str) to be supported by cosmolog.

Also fixed a locale issue for tox.

