### PR TITLE
Support python 3.10

### DIFF
--- a/cosmolog/cosmologger.py
+++ b/cosmolog/cosmologger.py
@@ -14,7 +14,10 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-import collections
+try:
+    import collections.abc as collections
+except ImportError:
+    import collections
 import json
 import logging
 import logging.config


### PR DESCRIPTION
The collections module moves some abstract classes into the abc submodules in py3. Update to support either the old or new locations.

https://github.com/python/cpython/pull/23754