### PR TITLE
Silence a warning from using collections directly rather than abc

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,11 +2,29 @@ name: Run tests
 on: [push, pull_request]
 
 jobs:
+  # Note that if we want to keep testing on Python 3.6, we need to test on
+  # an older ubuntu. Once we don't care about 3.6 any longer we can drop this.
+  test-client-old-python:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python: ['3.6']
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Test
+        run: |
+          pip install -e .[test]
+          py.test
   test-client:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.8, 3.9, '3.10']
+        python: [3.8, 3.9, '3.10']
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2.2.2

--- a/cosmolog/cosmologger.py
+++ b/cosmolog/cosmologger.py
@@ -14,10 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-try:
-    import collections.abc as collections
-except ImportError:
-    import collections
 import json
 import logging
 import logging.config
@@ -30,6 +26,10 @@ from dateutil.parser import parse as dateparse
 from pytz import utc
 from past.builtins import long, unicode, basestring
 from builtins import str as newstr
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 
 FATAL = 100
@@ -175,7 +175,7 @@ class CosmologEvent(dict):
 
     @classmethod
     def _validate_payload(cls, payload):
-        if not isinstance(payload, collections.Mapping):
+        if not isinstance(payload, Mapping):
             msg = ('Invalid payload: "{}". '
                    'Payload must be a dictionary, not type {}'
                    ).format(payload, type(payload))


### PR DESCRIPTION
We weren't actually doing that, we were just renaming the import, but this way everyone isn't annoyed by the warning.