### PR TITLE
Fixed including cosmolog bin package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ test = [
 human = "cosmolog.bin.cli:human"
 
 [tool.setuptools]
-packages = ["cosmolog"]
+packages = ["cosmolog", "cosmolog.bin"]
 
 [tool.versioningit]
 default-version = "0.0.0"  # for shallow clones in CI


### PR DESCRIPTION
Relying on setuptools automatic package discovery doesn't seem to work well for this directory layout, so we explicity set the packages list.