### PR TITLE
Remove use of deprecated datetime function

### DIFF
--- a/cosmolog/cosmologger.py
+++ b/cosmolog/cosmologger.py
@@ -156,7 +156,7 @@ class CosmologEvent(dict):
             except ValueError:
                 t = dateparse(t)
         elif isinstance(t, (int, float)):
-            t = datetime.utcfromtimestamp(t)
+            t = datetime.fromtimestamp(t, utc)
         else:
             msg = 'Unable to parse {} ({}) to UTC time'.format(t, type(t))
             raise CosmologgerException(msg)


### PR DESCRIPTION
I am seeing the following error in an app that uses cosmologger, this change cleans it up:

    /usr/local/lib/python3.12/dist-packages/cosmolog/cosmologger.py:159: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
      t = datetime.utcfromtimestamp(t)